### PR TITLE
Pump logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,10 @@ In boil mode, the heater will be constantly on until the target Temperature is a
 * Max. PID Temperature - If Target Temperature is set above this, PID will be disabled and Boil Mode will turn on.
 * Max. Boil Output - Heater power when Max Boil Temperature is reached.
 * Max. Boil Temperature - When Temperature reaches this, power will be reduced to Max Boil Output.
+
+* Internal Loop Time - In seconds, how quickly the internal loop will run, dictates maximum PID resolution (e.g. 0.1). The lower the more accurate but more demading on your Pi. You should also consider how fast your relays etc can switch when setting this.
+
+* Mash Pump Rest Interval - In seconds, how long the pump will run during mash phase before resting.
+* Mash Pump Rest Time - How long the pump will be off during the rest interval
+
+* Pump Max Temp - The pump will be switched off and rest logic disabled after the boil reaches this temperature. If the temperature falls the pump will be switched back on but rest logic will remain disabled.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# PID Logic with boil threshold and boil power reduction.
+# PID Logic with Boil and Pump control
+
+Forked from [https://github.com/TChilderhose/cbpi-pidsmartboil](PID Smart Boil) by [https://github.com/TChilderhose](TChilderhose) and extended to be able to pulse the pump during the mash phase.
+
+These modficitions have been made so that CraftBeerPi3 would be better able to control single vessel breweries with integrated pumps.
 
 If the target Temperature is above a configurable "Max. PID Temperature" threshold the PID will be ignored and heater is switched into boil mode. This is helpful if you use the same kettle for mashing and boiling.
 

--- a/__init__.py
+++ b/__init__.py
@@ -68,10 +68,13 @@ class PIDSmartBoilWithPump(KettleController):
             self._logger.debug("calculation cycle")
             inner_loop_now = calculation_loop_start = time.time()
             next_calculation_time = calculation_loop_start + sampleTime
+            target_temp = self.get_target_temp()
+            current_temp = self.get_temp()
+            boil_mode = target_temp > maxtemppid
 
-            if self.get_target_temp() < maxtemppid: #PID                
-                heat_percent = pid.calc(self.get_temp(), self.get_target_temp())
-            elif self.get_temp() < maxtempboil: #Boil Ramp    
+            if not boil_mode: #PID
+                heat_percent = pid.calc(current_temp, target_temp)
+            elif current_temp < maxtempboil: #Boil Ramp
                 heat_percent = maxoutput
             else: #Boil Sustain
                 heat_percent = maxoutputboil


### PR DESCRIPTION
This allows the kettle logic to pulse the pump during the mash phase.

Also has a safety cut off which turns the pump off during boil phase after the temperature reaches a configurable value.